### PR TITLE
Update index.vue

### DIFF
--- a/pages/isovis/index.vue
+++ b/pages/isovis/index.vue
@@ -454,7 +454,7 @@ export default
             const signal = this.controller.signal;
 
             // Search for Ensembl gene IDs by gene symbol from mygene.info
-            let data = await fetch(`https://mygene.info/v3/query?species=${this.taxon_id}&fields=symbol,ensembl.gene&q=symbol:${this.enteredGene}*`, { signal })
+            let data = await fetch(`https://mygene.info/v3/query?species=${this.taxon_id}&fields=symbol,ensembl.gene&q=symbol:${this.enteredGene}*&size=30`, { signal })
                 .then(res => res.json())
                 .catch(() => {});
 


### PR DESCRIPTION
This change closes https://github.com/ClarkLaboratory/IsoVis/issues/2  Turns out that the issue is that IsoVis is querying the mygene.info API to map gene ids to gene names.  By default, mygene.info returns a max of 10 results for each gene matching the query: ("TP53*").  In the case of TP53, there are dozens of genes beginning with the string "TP53" (e.g. TP53I3, TP53BP1, TP53INP2, etc).  It so happens that TP53 alone is not in the top 10 results returned, and so can never be accessed.  

Adding the "size" parameter with a larger number (we'll try 30 for now) returns more results, including the expected hit for TP53.